### PR TITLE
#82 : ScriptID in server create not working properly

### DIFF
--- a/vultr/resource_vultr_server.go
+++ b/vultr/resource_vultr_server.go
@@ -243,8 +243,9 @@ func resourceVultrServerCreate(d *schema.ResourceData, meta interface{}) error {
 	appID, appOK := d.GetOk("app_id")
 	isoID, isoOK := d.GetOk("iso_id")
 	snapID, snapOK := d.GetOk("snapshot_id")
+	scriptID, scriptOK := d.GetOk("script_id")
 
-	osOptions := map[string]bool{"os_id": osOK, "app_id": appOK, "iso_id": isoOK, "snapshot_id": snapOK}
+	osOptions := map[string]bool{"os_id": osOK, "app_id": appOK, "iso_id": isoOK, "snapshot_id": snapOK, "script_id": scriptOK}
 	osOption, err := optionCheck(osOptions)
 
 	if err != nil {
@@ -254,7 +255,6 @@ func resourceVultrServerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client).govultrClient()
 
 	options := &govultr.ServerOptions{
-		ScriptID:             d.Get("script_id").(string),
 		EnableIPV6:           d.Get("enable_ipv6").(bool),
 		EnablePrivateNetwork: d.Get("enable_private_network").(bool),
 		Label:                d.Get("label").(string),
@@ -287,6 +287,10 @@ func resourceVultrServerCreate(d *schema.ResourceData, meta interface{}) error {
 	case "snapshot_id":
 		options.SnapshotID = snapID.(string)
 		os = osSnapID
+
+	case "script_id":
+		options.ScriptID = scriptID.(string)
+		os = osIsoID
 
 	default:
 		return errors.New("Error occurred while getting your intended os type")


### PR DESCRIPTION
## Description
Script ID was not being properly handled  properly during server creation. This was due to `script_id` requiring `os_id : 159`. With the current setup we don't require you to pass in the special os codes for app or snapshot. However with `script_id` this was causing colliding with our logic since `script_id` requires the same `os_id` as snapshot. 

Updated the code so that `script_id` can be used without having to provide `os_id : 159` which is the custom os. This will now fall in line with:

- os_id
- app_id
- snapshot_id

You can now use `script_id` the same way you would use the attributes listed above

## Related Issues
Relates to open bug issue #82 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
