### PR TITLE
#84 : add error for protocol to be lower case

### DIFF
--- a/docs/r/firewall_rule.html.markdown
+++ b/docs/r/firewall_rule.html.markdown
@@ -20,7 +20,7 @@ resource "vultr_firewall_group" "my_firewallgroup" {
 
 resource "vultr_firewall_rule" "my_firewallrule" {
     firewall_group_id = "${vultr_firewall_group.my_firewallgroup.id}"
-    protocol = "TCP"
+    protocol = "tcp"
     network = "0.0.0.0/0"
     from_port = "8085"
     to_port = "8090"
@@ -32,7 +32,7 @@ resource "vultr_firewall_rule" "my_firewallrule" {
 The following arguments are supported:
 
 * `firewall_group_id` - (Required) The firewall group that the firewall rule will belong to.
-* `protocol` - (Required) The type of protocol for this firewall rule. Possible values (icmp, tcp, udp, gre)
+* `protocol` - (Required) The type of protocol for this firewall rule. Possible values (icmp, tcp, udp, gre) **Note** they must be lowercase
 * `network` - (Required) IP address that you want to define for this firewall rule.
 * `from_port` - (Optional) Port that you want to define for this rule.
 * `to_port` - (Optional) This can be used with the from port if you want to define multiple ports. Example from port 8085 to port 8090

--- a/vultr/resource_vultr_firewall_rule.go
+++ b/vultr/resource_vultr_firewall_rule.go
@@ -78,6 +78,11 @@ func resourceVultrFirewallRuleCreate(d *schema.ResourceData, meta interface{}) e
 	to, toOk := d.GetOk("to_port")
 
 	port := ""
+
+	if protocol != strings.ToLower(protocol) {
+		return fmt.Errorf("%q is required to be all lowercase", protocol)
+	}
+
 	if protocol == "tcp" || protocol == "udp" {
 		if fromOk {
 			if fromOk && toOk {


### PR DESCRIPTION
## Description
This is adding in a layer of error handling on the protocol to notify the user that the protocol needs to be all lowercase. I tried making it case insensitive however the API will always return the protocol back in the read as lowercase. This will cause a mismatch between your tf statefile and what is being returned. 



## Related Issues
#84 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
