### PR TITLE
fix for bug in server create

### DIFF
--- a/docs/r/server.html.markdown
+++ b/docs/r/server.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `region_id` - (Required) The ID of the region that the server is to be created in.
 * `plan_id` - (Required) The ID of the plan that you want the server to subscribe to.
-* `os_id` - (Optional) The ID of the operating system to be installed on the server.
+* `os_id` - (Required) The ID of the operating system to be installed on the server.
 * `iso_id` - (Optional) The ID of the ISO file to be installed on the server.
 * `app_id` - (Optional) The ID of the Vultr application to be installed on the server.
 * `snapshot_id` - (Optional) The ID of the Vultr snapshot that the server will restore for the initial installation. 


### PR DESCRIPTION
## Description
Due to the how a server can be created and different matching options we had to simplify the process. You will now have to supply the corresponding `os_id` with `snapshots`, `iso` `app`.

This will resolve any strange behaviors that may have been experienced before since we were trying to abstract out the `os_id`.

## Related Issues
none

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
