### PR TITLE
Server Options Bug

### DIFF
--- a/docs/r/server.html.markdown
+++ b/docs/r/server.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `region_id` - (Required) The ID of the region that the server is to be created in.
 * `plan_id` - (Required) The ID of the plan that you want the server to subscribe to.
-* `os_id` - (Required) The ID of the operating system to be installed on the server.
+* `os_id` - (Optional) The ID of the operating system to be installed on the server.
 * `iso_id` - (Optional) The ID of the ISO file to be installed on the server.
 * `app_id` - (Optional) The ID of the Vultr application to be installed on the server.
 * `snapshot_id` - (Optional) The ID of the Vultr snapshot that the server will restore for the initial installation. 

--- a/vultr/resource_vultr_server.go
+++ b/vultr/resource_vultr_server.go
@@ -272,6 +272,8 @@ func resourceVultrServerCreate(d *schema.ResourceData, meta interface{}) error {
 	// If no osOptions where selected and osID has a real value then set the osOptions to osID
 	if osOption == "" && osID.(int) != 0 {
 		osOption = "os_id"
+	} else if osOption != "" && osID.(int) != 0 {
+		return errors.New(fmt.Sprintf("Please do not set %s with os_id", osOption))
 	}
 
 	switch osOption {


### PR DESCRIPTION
## Description
Due to V1 API behavior we have been running into issues with terraform drifting due to values changes from initial server creation to server created process. 

While trying to solve these pain points we have a found a few other API V1 constraints which have been addressed. 

Users now do not have to know the corresponding `os_id` for

- app
- iso
- snapshot

If you define `snapshot_id`, `iso_id` or `app_id` we now handle adding the proper `os_id`.

If you want to deploy a regular os you can define your `os_id`.
https://api.vultr.com/v1/os/list

**NOTE** If you set os_id with either `app_id`, `iso_id`, or `snapshot_id` an error will be thrown

If you want to use a startup script you can either use a regular `boot` script with an `app_id` or regular `os_id`

However if you want to use a `pxe` script then you will need to use the `os_id = 159`

Also note this shouldn't break backwards comp since the desired TF state should still match the defined TF state since the `os_id` will match up with what TF gets back from the API 

## Related Issues
#96 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
