### PR TITLE
Fix link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ln -s $GOPATH/bin/terraform-provider-vultr ~/.terraform.d/plugins/terraform-pro
 Using the provider
 ----------------------
 
-See the [Vultr Provider documentation](docs/index.html.markdown) to get started using the Vultr provider.
+See the [Vultr Provider documentation](website/docs/index.html.markdown) to get started using the Vultr provider.
 
 Developing the Provider
 ---------------------------


### PR DESCRIPTION
## Description

This PR fixes a link to the Terraform provider documentation in the README.md file. Currently, the link leads to a 404 page.

## Related Issues

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
